### PR TITLE
Add Beta patch notes link (temporarily)

### DIFF
--- a/cogs/overwatch.py
+++ b/cogs/overwatch.py
@@ -75,7 +75,7 @@ class Overwatch(commands.Cog):
         """Returns Overwatch patch notes links."""
         embed = discord.Embed(color=self.bot.color(ctx.author.id))
         embed.title = "Overwatch Patch Notes"
-        categories = ("Live", "PTR", "Experimental")
+        categories = ("Live", "PTR", "Experimental", "Beta")
         description = []
         for category in categories:
             link = self.bot.config.overwatch["patch"].format(category.lower())


### PR DESCRIPTION
Supposedly, there's going to be a third beta, and this change would've been minorly handy during the first two.

However, **you can still click any of the other links, then to beta..so feel free to deny this PR.**

Scraping the page for available options first could work? But adds an extra request.

```
<div class="PatchNotes-types"><button class="Button PatchNotes-type PatchNotes-type-live PatchNotes-type--selected" disabled="" data-type="live" data-analytics-placement="live">Live</button><button class="Button PatchNotes-type PatchNotes-type-ptr " data-type="ptr" data-analytics-placement="ptr">PTR</button><button class="Button PatchNotes-type PatchNotes-type-experimental " data-type="experimental" data-analytics-placement="experimental">Experimental</button><button class="Button PatchNotes-type PatchNotes-type-beta " data-type="beta" data-analytics-placement="beta">Beta</button></div>
```